### PR TITLE
Ignore text in X<> formatting code

### DIFF
--- a/lib/Test/Pod/LinkCheck/Lite.pm
+++ b/lib/Test/Pod/LinkCheck/Lite.pm
@@ -1010,7 +1010,7 @@ sub run {
 	defined $source
 	    and $self->set_source( $source );
     my $attr = $self->_attr();
-    @{ $attr }{ qw{ line links sections } } = ( 1, [], {} );
+    @{ $attr }{ qw{ line links sections ignore_tag } } = ( 1, [], {}, [] );
     while ( my $token = $self->get_token() ) {
 	if ( my $code = $self->can( '__token_' . $token->type() ) ) {
 	    $code->( $self, $token );
@@ -1054,6 +1054,8 @@ sub __token_start {
 	    @{ $sect }[ 2 .. $#$sect ] = ( _normalize_text( "$sect" ) );
 	}
 	push @{ $attr->{links} }, [ @{ $token }[ 1 .. $#$token ] ];
+    } elsif ( 'X' eq $tag ) {
+	push @{ $attr->{ignore_tag} }, $tag;
     } elsif ( $section_tag{$tag} ) {
 	$attr->{text} = '';
     }
@@ -1063,6 +1065,7 @@ sub __token_start {
 sub __token_text {
     my ( $self, $token ) = @_;
     my $attr = $self->_attr();
+    return if @{ $attr->{ignore_tag} };
     my $text = $token->text();
     $attr->{line} += $text =~ tr/\n//;
     $attr->{text} .= $text;
@@ -1075,6 +1078,8 @@ sub __token_end {
     my $tag = $token->tag();
     if ( $section_tag{$tag} ) {
 	$attr->{sections}{ _normalize_text( delete $attr->{text} ) } = 1;
+    } elsif( @{ $attr->{ignore_tag} } && $tag eq $attr->{ignore_tag}[-1] ) {
+	pop @{ $attr->{ignore_tag} };
     }
     return;
 }

--- a/t/data/pod_ok/external_builtin.pod
+++ b/t/data/pod_ok/external_builtin.pod
@@ -2,6 +2,9 @@
 
 This POD contains a link to a built-in command, L<unlink|unlink>.
 
+And a link to a section which has an C<< XE<lt>E<gt> >> formatting code that must be
+ignored: L<perlpod/Ordinary Paragraph>.
+
 =cut
 
 # ex: set textwidth=72 :


### PR DESCRIPTION
This allows for linking to section tags that might contain an `X<>` such as
some in documentation that comes with Perl.
